### PR TITLE
Remove sticky note board label

### DIFF
--- a/src/plugin.ts
+++ b/src/plugin.ts
@@ -38,7 +38,6 @@ penpot.ui.onMessage<{ type: string; data: any }>(async (message) => {
       }
     ]
     board.resize(300, 300)
-    board.name = '📝 from ' + currentUser.name
     board.borderRadius = 8
 
     const verticalFlex = board.addFlexLayout();


### PR DESCRIPTION
## Summary
- don't name sticky note boards

## Testing
- `npm run lint` *(fails: Invalid option '--ignore-path')*
- `npm run type-check` *(fails: vue-tsc not found)*

------
https://chatgpt.com/codex/tasks/task_e_687245d49c288321a78f9715edadffd1